### PR TITLE
fix: handle Microsoft SharePoint client connection error

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ asyncio.run(update_thies_data())
 
 **Notes:** 
 - Store sensitive data like `FTP_PASSWORD`, `FTP_USER`, and SharePoint credentials securely. Use environment variables or a secrets management tool to avoid hardcoding sensitive information in your codebase.
-- Ensure `asyncio` is installed to run concurrent code with `EpiiAPI` methods.
 
 ## Development
 

--- a/src/rcer_iot_client_pkg/general_types/error_types/api/update_thies_data_error_types.py
+++ b/src/rcer_iot_client_pkg/general_types/error_types/api/update_thies_data_error_types.py
@@ -1,3 +1,6 @@
+import json
+
+
 class ThiesConnectionError(Exception):
     """Raised when unable to connect to the THIES FTP Server"""
 
@@ -26,5 +29,15 @@ class ThiesFetchingError(Exception):
 class SharePointFetchingError(Exception):
     """Raised when there is an error fetching file names from the RCER cloud."""
 
+    def __init__(self, *args, reason):
+        super().__init__(*args, reason)
+        self.reason = reason
+
     def __str__(self):
-        return "An error occurred while retrieving file names from the RCER cloud"
+        try:
+            _, internal_metadata = self.reason.__str__().split(",", 1)
+            internal_metadata_dict = json.loads(internal_metadata)
+            return internal_metadata_dict["error_description"]
+
+        except json.decoder.JSONDecodeError:
+            return self.reason.__str__()

--- a/src/rcer_iot_client_pkg/libs/sharepoint_client/clients/sharepoint_rest_api.py
+++ b/src/rcer_iot_client_pkg/libs/sharepoint_client/clients/sharepoint_rest_api.py
@@ -65,17 +65,22 @@ class SharepointRestAPI(SharepointClientContract):
             }
 
     async def __aenter__(self) -> "SharepointRestAPI":
-        self.credentials = await self._load_credentials()
-        site_url = f"https://{self.tenant_name}.sharepoint.com"
+        try:
+            self.credentials = await self._load_credentials()
+            site_url = f"https://{self.tenant_name}.sharepoint.com"
 
-        self.base_headers = {
-            "Authorization": f"Bearer {self.credentials['access_token']}",
-            "Accept": "application/json",
-            "Content-Type": "application/json",
-        }
-        self.base_url = f"{site_url}/sites/{self.site_name}/_api/"
-        self.session = ClientSession(headers=self.base_headers, base_url=self.base_url)
-        return self
+            self.base_headers = {
+                "Authorization": f"Bearer {self.credentials['access_token']}",
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+            }
+            self.base_url = f"{site_url}/sites/{self.site_name}/_api/"
+            self.session = ClientSession(
+                headers=self.base_headers, base_url=self.base_url
+            )
+            return self
+        except ClientError as error:
+            raise ConnectionError(error)
 
     async def __aexit__(
         self, _exc_type: type[BaseException], _exc_val: BaseException, _exc_tb: Any

--- a/src/rcer_iot_client_pkg/services/epii/controllers/update_thies_data.py
+++ b/src/rcer_iot_client_pkg/services/epii/controllers/update_thies_data.py
@@ -73,14 +73,14 @@ class UpdateThiesDataController:
         except SharepointClientError as error:
             return UpdateThiesDataControllerOutput(
                 message="Sharepoint Client initialization fails.",
-                status=HTTPStatus.BAD_REQUEST.value,
+                status=HTTPStatus.INTERNAL_SERVER_ERROR.value,
                 metadata={"error": error.__str__()},
             )
 
         except SharePointFetchingError as error:
             return UpdateThiesDataControllerOutput(
-                message="An error occurred while retrieving file names from the RCER cloud",
-                status=HTTPStatus.INTERNAL_SERVER_ERROR.value,
+                message="An error occurred while retrieving file names from Microsoft SharePoint",
+                status=HTTPStatus.BAD_REQUEST.value,
                 metadata={"error": error.__str__()},
             )
 

--- a/tests/epii/controllers/test_update_thies_data_controller.py
+++ b/tests/epii/controllers/test_update_thies_data_controller.py
@@ -80,7 +80,7 @@ class TestUpdateThiesDataControllerExecute(unittest.IsolatedAsyncioTestCase):
         result = await controller.execute()
 
         self.assertEqual(result.message, "Sharepoint Client initialization fails.")
-        self.assertEqual(result.status, 400)
+        self.assertEqual(result.status, 500)
         self.assertIn("SharePoint", result.metadata["error"])
 
     @patch(
@@ -88,7 +88,9 @@ class TestUpdateThiesDataControllerExecute(unittest.IsolatedAsyncioTestCase):
     )
     async def test_should_handle_sharepoint_fetching_error(self, mock_use_case):
         mock_use_case_inst = mock_use_case.return_value
-        mock_use_case_inst.execute.side_effect = SharePointFetchingError("Fetch error")
+        mock_use_case_inst.execute.side_effect = SharePointFetchingError(
+            reason="any, {error: error}"
+        )
 
         controller = UpdateThiesDataController(
             UpdateThiesDataControllerInput(self.config)
@@ -98,10 +100,9 @@ class TestUpdateThiesDataControllerExecute(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(
             result.message,
-            "An error occurred while retrieving file names from the RCER cloud",
+            "An error occurred while retrieving file names from Microsoft SharePoint",
         )
-        self.assertEqual(result.status, 500)
-        self.assertIn("RCER cloud", result.metadata["error"])
+        self.assertEqual(result.status, 400)
 
     @patch(
         "rcer_iot_client_pkg.services.epii.controllers.update_thies_data.UpdateThiesDataUseCase"


### PR DESCRIPTION
This PR enhances error handling for the SharePoint integration and updates related status codes and test cases for improved clarity and accuracy.

### 🔧 Key Changes

- Added support for a `reason` field in `SharePointFetchingError`, with JSON parsing and fallback handling.
- Wrapped `ClientError` exceptions in `__aenter__` with a more descriptive `ConnectionError`.
- Refined error messages and adjusted HTTP status codes to better reflect error contexts.

### 🧪 Tests

- Updated test cases to reflect new error messages and structure.
- Mocked `SharePointFetchingError` now includes a `reason` attribute.

These changes improve debuggability and make error responses more consistent.
